### PR TITLE
Add React-based UK Train Excuse Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # TrainExcuse
-Creative UK train excuse generators. These excuses are for entertainment purposes only. Please don't actually use them with your boss (unless they have a sense of humor).
+
+Creative UK train excuse generator.
+
+Open `index.html` in a browser to generate a humorous excuse.
+These excuses are for entertainment purposes only. Please don't actually use them with your boss (unless they have a sense of humor).

--- a/app.jsx
+++ b/app.jsx
@@ -1,0 +1,35 @@
+function App() {
+  const [excuse, setExcuse] = React.useState('');
+
+  const excuses = [
+    "Signal failure caused by stray sheep on the tracks.",
+    "Driver delayed after stopping to rescue a royal corgi.",
+    "Leaves on the line formed into a protest march.",
+    "Points frozen by an unexpected ice cream truck.",
+    "Train held up while staff made a perfect cup of tea.",
+    "Delay due to a pigeon refusing to vacate the driver's seat.",
+    "Tardis parked on platform 9 blocking departure.",
+    "Conductor stuck in queue at the chippy.",
+    "Unexpected detour to scenic countryside for photo ops.",
+    "Tracks temporarily borrowed by the Hogwarts Express."
+  ];
+
+  const generateExcuse = () => {
+    const randomExcuse = excuses[Math.floor(Math.random() * excuses.length)];
+    setExcuse(randomExcuse);
+  };
+
+  return (
+    <div className="container">
+      <header>
+        <span className="icon" role="img" aria-label="train">🚆</span>
+        <h1>UK Train Excuse Generator</h1>
+      </header>
+      <button onClick={generateExcuse}>Generate Excuse</button>
+      {excuse && <p className="excuse">{excuse}</p>}
+    </div>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UK Train Excuse Generator</title>
+  <link rel="stylesheet" href="style.css" />
+  <!-- React and Babel CDN -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,59 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: #f2f2f2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  text-align: center;
+  padding: 1rem;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+header .icon {
+  font-size: 3rem;
+}
+
+h1 {
+  margin-top: 0.5rem;
+  font-size: 1.8rem;
+}
+
+button {
+  background-color: #0078d7;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #005fa3;
+}
+
+.excuse {
+  margin-top: 1rem;
+  font-size: 1.2rem;
+  color: #333;
+}
+
+@media (max-width: 600px) {
+  h1 {
+    font-size: 1.5rem;
+  }
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- Add one-page React app that generates random humorous UK train excuses.
- Style page for mobile-friendly layout with centered header, train icon, and button.
- Update README with instructions for using the generator.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68af0a383aec8330b75946c7001b19be