### PR TITLE
Add test suite for UK Train Excuse Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/App.jsx
+++ b/App.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export const excuses = [
+  "Signal failure caused by stray sheep on the tracks.",
+  "Driver delayed after stopping to rescue a royal corgi.",
+  "Leaves on the line formed into a protest march.",
+  "Points frozen by an unexpected ice cream truck.",
+  "Train held up while staff made a perfect cup of tea.",
+  "Delay due to a pigeon refusing to vacate the driver's seat.",
+  "Tardis parked on platform 9 blocking departure.",
+  "Conductor stuck in queue at the chippy.",
+  "Unexpected detour to scenic countryside for photo ops.",
+  "Tracks temporarily borrowed by the Hogwarts Express."
+];
+
+export default function App() {
+  const [excuse, setExcuse] = React.useState('');
+
+  const generateExcuse = () => {
+    const randomExcuse = excuses[Math.floor(Math.random() * excuses.length)];
+    setExcuse(randomExcuse);
+  };
+
+  return (
+    <div className="container">
+      <header>
+        <span className="icon" role="img" aria-label="train">🚆</span>
+        <h1>UK Train Excuse Generator</h1>
+      </header>
+      <button onClick={generateExcuse}>Generate Excuse</button>
+      {excuse && <p className="excuse" data-testid="excuse">{excuse}</p>}
+    </div>
+  );
+}

--- a/App.test.jsx
+++ b/App.test.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App, { excuses } from './App.jsx';
+
+test('no excuse is shown on initial render', () => {
+  render(<App />);
+  expect(screen.queryByTestId('excuse')).toBeNull();
+});
+
+test('generates an excuse when button is clicked', () => {
+  render(<App />);
+  fireEvent.click(screen.getByText('Generate Excuse'));
+  const displayed = screen.getByTestId('excuse');
+  expect(excuses).toContain(displayed.textContent);
+});

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # TrainExcuse
-Creative UK train excuse generators. These excuses are for entertainment purposes only. Please don't actually use them with your boss (unless they have a sense of humor).
+
+Creative UK train excuse generator.
+
+Open `index.html` in a browser to generate a humorous excuse.
+These excuses are for entertainment purposes only. Please don't actually use them with your boss (unless they have a sense of humor).
+
+## Testing
+
+Install dependencies and run the test suite:
+
+```bash
+npm install
+npm test
+```

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react', {runtime: 'automatic'}]
+  ]
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UK Train Excuse Generator</title>
+  <link rel="stylesheet" href="style.css" />
+  <!-- React and Babel CDN -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" data-type="module" src="index.jsx"></script>
+</body>
+</html>

--- a/index.jsx
+++ b/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "train-excuse",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.23.0",
+    "@babel/preset-react": "^7.22.5",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.0.0",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,59 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: #f2f2f2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.container {
+  text-align: center;
+  padding: 1rem;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+header .icon {
+  font-size: 3rem;
+}
+
+h1 {
+  margin-top: 0.5rem;
+  font-size: 1.8rem;
+}
+
+button {
+  background-color: #0078d7;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #005fa3;
+}
+
+.excuse {
+  margin-top: 1rem;
+  font-size: 1.2rem;
+  color: #333;
+}
+
+@media (max-width: 600px) {
+  h1 {
+    font-size: 1.5rem;
+  }
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- refactor React app into an exportable component and mount script
- add Jest and React Testing Library tests for excuse generation
- document testing workflow in README

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af0a383aec8330b75946c7001b19be